### PR TITLE
Fix dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ It is free/libre and gratis software.
 Download
 ---
 
-* [Google Play Store](https://play.google.com/store/apps/details?id=eu.mrogalski.saidit)
 * [F-Droid](https://f-droid.org/repository/browse/?fdid=eu.mrogalski.saidit)
 
 Building
 ---
 
 1. Install gradle-1.10 (version is important)
-2. Create Key Store - http://stackoverflow.com/questions/3997748/how-can-i-create-a-keystore
-3. Fill Key Store details in `SaidIt/build.gradle`
-4. From this directory run `gradle installDebug` - to install it on a phone or `gradle assembleRelease` - to generate signed APK
+1. Install SDK platform API 21 and 21.0.2 build-tools, with either [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager) or [Android Studio](https://developer.android.com/studio)
+1. Create a Key Store - [Instructions](http://stackoverflow.com/questions/3997748/how-can-i-create-a-keystore)
+1. Fill Key Store details in `SaidIt/build.gradle`
+1. From this directory run `gradle installDebug` - to install it on a phone or `gradle assembleRelease` - to generate signed APK
 
 If you had any issues and fixed them, please correct these instructions in your fork!

--- a/SaidIt/build.gradle
+++ b/SaidIt/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url "https://repo.maven.apache.org/maven2" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.11.+'
@@ -9,7 +9,8 @@ buildscript {
 apply plugin: 'android'
 
 repositories {
-    mavenCentral()
+        jcenter()
+        maven { url "https://maven.google.com" }
 }
 
 android {
@@ -47,7 +48,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.android.support:appcompat-v7:+'
+    compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.nineoldandroids:library:2.4.0'
-    compile 'com.android.support:support-v4:21.+'
+    compile 'com.android.support:support-v4:21.0.3'
 }


### PR DESCRIPTION
This will allow this app to be built on newer installations.  

As HTTPS is now a requirement and gradle 1.10 doesn't use it by default, URLs need to be explicitly specified to avoid a 501 error.
Also updated instructions to specify that certain SDK versions and build tools are needed and where to get them.
Removed + from dependencies in gradle build file as it is bad practice and introduces errors.