### PR TITLE
Add active hours schedule feature

### DIFF
--- a/SaidIt/src/main/java/eu/mrogalski/saidit/BroadcastReceiver.java
+++ b/SaidIt/src/main/java/eu/mrogalski/saidit/BroadcastReceiver.java
@@ -2,14 +2,39 @@ package eu.mrogalski.saidit;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+
+import java.util.Calendar;
 
 public class BroadcastReceiver extends android.content.BroadcastReceiver {
 
 	@Override
 	public void onReceive(Context context, Intent intent) {
-        // Start only if tutorial has been finished
-        if (context.getSharedPreferences(SaidIt.PACKAGE_NAME, Context.MODE_PRIVATE).getBoolean("skip_tutorial", false)) {
-            context.startService(new Intent(context, SaidItService.class));
+        SharedPreferences prefs = context.getSharedPreferences(SaidIt.PACKAGE_NAME, Context.MODE_PRIVATE);
+        if (!prefs.getBoolean("skip_tutorial", false)) {
+            return;
+        }
+        if (prefs.getBoolean(SaidIt.SCHEDULE_ENABLED_KEY, false) && !isWithinSchedule(prefs)) {
+            return;
+        }
+        context.startForegroundService(new Intent(context, SaidItService.class));
+    }
+
+    private static boolean isWithinSchedule(SharedPreferences prefs) {
+        int startHour = prefs.getInt(SaidIt.SCHEDULE_START_HOUR_KEY, 8);
+        int startMinute = prefs.getInt(SaidIt.SCHEDULE_START_MINUTE_KEY, 0);
+        int endHour = prefs.getInt(SaidIt.SCHEDULE_END_HOUR_KEY, 23);
+        int endMinute = prefs.getInt(SaidIt.SCHEDULE_END_MINUTE_KEY, 0);
+
+        Calendar now = Calendar.getInstance();
+        int nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+        int startMinutes = startHour * 60 + startMinute;
+        int endMinutes = endHour * 60 + endMinute;
+
+        if (startMinutes <= endMinutes) {
+            return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+        } else {
+            return nowMinutes >= startMinutes || nowMinutes < endMinutes;
         }
     }
 }

--- a/SaidIt/src/main/java/eu/mrogalski/saidit/SaidIt.java
+++ b/SaidIt/src/main/java/eu/mrogalski/saidit/SaidIt.java
@@ -6,6 +6,11 @@ public class SaidIt {
     static final String AUDIO_MEMORY_ENABLED_KEY = "audio_memory_enabled";
     static final String AUDIO_MEMORY_SIZE_KEY = "audio_memory_size";
     static final String SAMPLE_RATE_KEY = "sample_rate";
+    static final String SCHEDULE_ENABLED_KEY = "schedule_enabled";
+    static final String SCHEDULE_START_HOUR_KEY = "schedule_start_hour";
+    static final String SCHEDULE_START_MINUTE_KEY = "schedule_start_minute";
+    static final String SCHEDULE_END_HOUR_KEY = "schedule_end_hour";
+    static final String SCHEDULE_END_MINUTE_KEY = "schedule_end_minute";
     static final String SKU = "unlimited_history";
     static final String BASE64_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlD0FMFGp4AWzjW" +
             "LTsUZgm0soga0mVVNGFj0qoATaoQCE/LamF7yrMCIFm9sEOB1guCEhzdr16sjysrVc2EPRisS83FoJ4K0R8" +

--- a/SaidIt/src/main/java/eu/mrogalski/saidit/SaidItService.java
+++ b/SaidIt/src/main/java/eu/mrogalski/saidit/SaidItService.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Calendar;
 
 import simplesound.pcm.WavAudioFormat;
 import simplesound.pcm.WavFileWriter;
@@ -67,13 +68,19 @@ public class SaidItService extends Service {
         audioHandler = new Handler(audioThread.getLooper());
 
         if(preferences.getBoolean(AUDIO_MEMORY_ENABLED_KEY, true)) {
-            innerStartListening();
+            if (isWithinSchedule()) {
+                innerStartListening();
+            }
+            if (preferences.getBoolean(SCHEDULE_ENABLED_KEY, false)) {
+                scheduleNextCheck();
+            }
         }
 
     }
 
     @Override
     public void onDestroy() {
+        cancelScheduleCheck();
         stopRecording(null, "");
         innerStopListening();
         stopForeground(true);
@@ -93,7 +100,13 @@ public class SaidItService extends Service {
         getSharedPreferences(PACKAGE_NAME, MODE_PRIVATE)
                 .edit().putBoolean(AUDIO_MEMORY_ENABLED_KEY, true).commit();
 
-        innerStartListening();
+        if (isWithinSchedule()) {
+            innerStartListening();
+        }
+        SharedPreferences prefs = getSharedPreferences(PACKAGE_NAME, MODE_PRIVATE);
+        if (prefs.getBoolean(SCHEDULE_ENABLED_KEY, false)) {
+            scheduleNextCheck();
+        }
     }
 
     public void disableListening() {
@@ -529,9 +542,86 @@ public class SaidItService extends Service {
         }
     }
 
+    private static final String ACTION_SCHEDULE_CHECK = "eu.mrogalski.saidit.SCHEDULE_CHECK";
+    private static final int SCHEDULE_CHECK_REQUEST_CODE = 2;
+    private static final long SCHEDULE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
+    boolean isWithinSchedule() {
+        final SharedPreferences prefs = getSharedPreferences(PACKAGE_NAME, MODE_PRIVATE);
+        if (!prefs.getBoolean(SCHEDULE_ENABLED_KEY, false)) {
+            return true;
+        }
+        int startHour = prefs.getInt(SCHEDULE_START_HOUR_KEY, 8);
+        int startMinute = prefs.getInt(SCHEDULE_START_MINUTE_KEY, 0);
+        int endHour = prefs.getInt(SCHEDULE_END_HOUR_KEY, 23);
+        int endMinute = prefs.getInt(SCHEDULE_END_MINUTE_KEY, 0);
+
+        Calendar now = Calendar.getInstance();
+        int nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE);
+        int startMinutes = startHour * 60 + startMinute;
+        int endMinutes = endHour * 60 + endMinute;
+
+        if (startMinutes <= endMinutes) {
+            return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+        } else {
+            return nowMinutes >= startMinutes || nowMinutes < endMinutes;
+        }
+    }
+
+    public void applySchedule() {
+        final SharedPreferences prefs = getSharedPreferences(PACKAGE_NAME, MODE_PRIVATE);
+        boolean listeningEnabled = prefs.getBoolean(AUDIO_MEMORY_ENABLED_KEY, true);
+
+        if (!listeningEnabled) {
+            return;
+        }
+
+        if (isWithinSchedule()) {
+            if (state == STATE_READY) {
+                innerStartListening();
+            }
+        } else {
+            if (state == STATE_LISTENING) {
+                innerStopListening();
+            }
+        }
+
+        scheduleNextCheck();
+    }
+
+    private void scheduleNextCheck() {
+        final SharedPreferences prefs = getSharedPreferences(PACKAGE_NAME, MODE_PRIVATE);
+        if (!prefs.getBoolean(SCHEDULE_ENABLED_KEY, false)) {
+            cancelScheduleCheck();
+            return;
+        }
+
+        Intent intent = new Intent(this, SaidItService.class);
+        intent.setAction(ACTION_SCHEDULE_CHECK);
+        PendingIntent pendingIntent = PendingIntent.getService(this, SCHEDULE_CHECK_REQUEST_CODE,
+                intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
+        alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + SCHEDULE_CHECK_INTERVAL_MS, pendingIntent);
+    }
+
+    private void cancelScheduleCheck() {
+        Intent intent = new Intent(this, SaidItService.class);
+        intent.setAction(ACTION_SCHEDULE_CHECK);
+        PendingIntent pendingIntent = PendingIntent.getService(this, SCHEDULE_CHECK_REQUEST_CODE,
+                intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_NO_CREATE);
+        if (pendingIntent != null) {
+            AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
+            alarmManager.cancel(pendingIntent);
+        }
+    }
+
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         startForeground(FOREGROUND_NOTIFICATION_ID, buildNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+        if (intent != null && ACTION_SCHEDULE_CHECK.equals(intent.getAction())) {
+            applySchedule();
+        }
         return START_STICKY;
     }
 

--- a/SaidIt/src/main/java/eu/mrogalski/saidit/SettingsActivity.java
+++ b/SaidIt/src/main/java/eu/mrogalski/saidit/SettingsActivity.java
@@ -1,10 +1,12 @@
 package eu.mrogalski.saidit;
 
 import android.app.Activity;
+import android.app.TimePickerDialog;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.graphics.Rect;
@@ -23,6 +25,7 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.TimePicker;
 
 import eu.mrogalski.StringFormat;
 import eu.mrogalski.android.TimeFormat;
@@ -68,6 +71,32 @@ public class SettingsActivity extends Activity {
 
     final TimeFormat.Result timeFormatResult = new TimeFormat.Result();
 
+    private void syncScheduleUI() {
+        final SharedPreferences prefs = getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE);
+        boolean scheduleEnabled = prefs.getBoolean(SaidIt.SCHEDULE_ENABLED_KEY, false);
+        int startHour = prefs.getInt(SaidIt.SCHEDULE_START_HOUR_KEY, 8);
+        int startMinute = prefs.getInt(SaidIt.SCHEDULE_START_MINUTE_KEY, 0);
+        int endHour = prefs.getInt(SaidIt.SCHEDULE_END_HOUR_KEY, 23);
+        int endMinute = prefs.getInt(SaidIt.SCHEDULE_END_MINUTE_KEY, 0);
+
+        Button toggle = (Button) findViewById(R.id.schedule_toggle);
+        Button startTime = (Button) findViewById(R.id.schedule_start_time);
+        Button endTime = (Button) findViewById(R.id.schedule_end_time);
+        View timesLayout = findViewById(R.id.schedule_times_layout);
+
+        toggle.setText(scheduleEnabled ? R.string.schedule_on : R.string.schedule_off);
+        toggle.setBackgroundResource(scheduleEnabled ? R.drawable.green_button : R.drawable.gray_button);
+
+        startTime.setText(String.format("%02d:%02d", startHour, startMinute));
+        endTime.setText(String.format("%02d:%02d", endHour, endMinute));
+
+        startTime.setBackgroundResource(scheduleEnabled ? R.drawable.green_button : R.drawable.gray_button);
+        endTime.setBackgroundResource(scheduleEnabled ? R.drawable.green_button : R.drawable.gray_button);
+        startTime.setEnabled(scheduleEnabled);
+        endTime.setEnabled(scheduleEnabled);
+        timesLayout.setAlpha(scheduleEnabled ? 1.0f : 0.4f);
+    }
+
     private void syncUI() {
         final long maxMemory = Runtime.getRuntime().maxMemory();
         System.out.println("maxMemory = " + maxMemory);
@@ -83,6 +112,7 @@ public class SettingsActivity extends Activity {
         ((TextView)findViewById(R.id.history_limit)).setText(timeFormatResult.text);
 
         highlightButtons();
+        syncScheduleUI();
     }
 
     void highlightButtons() {
@@ -167,6 +197,63 @@ public class SettingsActivity extends Activity {
         initSampleRateButton(root, R.id.quality_48kHz, 48000, 44100);
 
         //debugPrintCodecs();
+
+        root.findViewById(R.id.schedule_toggle).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SharedPreferences prefs = getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE);
+                boolean enabled = prefs.getBoolean(SaidIt.SCHEDULE_ENABLED_KEY, false);
+                prefs.edit().putBoolean(SaidIt.SCHEDULE_ENABLED_KEY, !enabled).apply();
+                syncScheduleUI();
+                if (service != null) {
+                    service.applySchedule();
+                }
+            }
+        });
+
+        root.findViewById(R.id.schedule_start_time).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SharedPreferences prefs = getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE);
+                int hour = prefs.getInt(SaidIt.SCHEDULE_START_HOUR_KEY, 8);
+                int minute = prefs.getInt(SaidIt.SCHEDULE_START_MINUTE_KEY, 0);
+                new TimePickerDialog(SettingsActivity.this, new TimePickerDialog.OnTimeSetListener() {
+                    @Override
+                    public void onTimeSet(TimePicker view, int hourOfDay, int minuteOfHour) {
+                        getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE).edit()
+                                .putInt(SaidIt.SCHEDULE_START_HOUR_KEY, hourOfDay)
+                                .putInt(SaidIt.SCHEDULE_START_MINUTE_KEY, minuteOfHour)
+                                .apply();
+                        syncScheduleUI();
+                        if (service != null) {
+                            service.applySchedule();
+                        }
+                    }
+                }, hour, minute, true).show();
+            }
+        });
+
+        root.findViewById(R.id.schedule_end_time).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SharedPreferences prefs = getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE);
+                int hour = prefs.getInt(SaidIt.SCHEDULE_END_HOUR_KEY, 23);
+                int minute = prefs.getInt(SaidIt.SCHEDULE_END_MINUTE_KEY, 0);
+                new TimePickerDialog(SettingsActivity.this, new TimePickerDialog.OnTimeSetListener() {
+                    @Override
+                    public void onTimeSet(TimePicker view, int hourOfDay, int minuteOfHour) {
+                        getSharedPreferences(SaidIt.PACKAGE_NAME, MODE_PRIVATE).edit()
+                                .putInt(SaidIt.SCHEDULE_END_HOUR_KEY, hourOfDay)
+                                .putInt(SaidIt.SCHEDULE_END_MINUTE_KEY, minuteOfHour)
+                                .apply();
+                        syncScheduleUI();
+                        if (service != null) {
+                            service.applySchedule();
+                        }
+                    }
+                }, hour, minute, true).show();
+            }
+        });
 
         dialog.setDescriptionStringId(R.string.work_preparing_memory);
 

--- a/SaidIt/src/main/res/layout/activity_settings.xml
+++ b/SaidIt/src/main/res/layout/activity_settings.xml
@@ -182,6 +182,79 @@
 
         -->
 
+        <TextView
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="5dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/schedule_title"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginTop="10dp"
+            android:gravity="center"
+            android:layout_marginBottom="10dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/schedule_toggle"
+                android:textSize="23sp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/schedule_off"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/schedule_times_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:gravity="center"
+            android:layout_marginBottom="10dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/schedule_from"
+                android:textSize="18sp"/>
+
+            <Button
+                android:id="@+id/schedule_start_time"
+                android:textSize="23sp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:layout_marginRight="20dp"
+                android:text="08:00"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/schedule_to"
+                android:textSize="18sp"/>
+
+            <Button
+                android:id="@+id/schedule_end_time"
+                android:textSize="23sp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="23:00"/>
+        </LinearLayout>
+
+        <TextView
+            style="@style/SmallText"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/schedule_description"/>
+
         <Button
             android:id="@+id/settings_return"
             android:layout_marginTop="20dp"

--- a/SaidIt/src/main/res/values/strings.xml
+++ b/SaidIt/src/main/res/values/strings.xml
@@ -113,6 +113,13 @@
     <string name="option_b_audio_quality">B) Sound quality</string>
     <string name="used_ram_description">Echo and other apps use system memory to keep their data. Large system memory consumption may slow other apps.</string>
     <string name="audio_quality_description">Quality of 8kHz is enough to recognize human speech. Higher options offer different tradeoffs between quality and memory consumption.</string>
+    <string name="schedule_title">C) Active hours</string>
+    <string name="schedule_description">When enabled, Echo will only listen during the specified hours. Outside these hours, the microphone is turned off to save battery.</string>
+    <string name="schedule_from">From</string>
+    <string name="schedule_to">To</string>
+    <string name="schedule_on">On</string>
+    <string name="schedule_off">Off</string>
+    <string name="schedule_paused_notification">Echo is paused (outside active hours)</string>
     <string name="settings_return">Return</string>
 
     <!-- Others -->


### PR DESCRIPTION
Allow users to configure a time window (e.g., 08:00–23:00) in Settings during which Echo listens. Outside active hours the microphone is turned off to save battery. A recurring AlarmManager check enforces the schedule.

Fixes #18 